### PR TITLE
fix make command

### DIFF
--- a/plugins/build/backends/make.lua
+++ b/plugins/build/backends/make.lua
@@ -11,7 +11,7 @@ function make.infer()
 end
 
 function make.build(target, callback)
-  build.run_tasks({ { "make", target.name, "-j", build.threads } }, function(status)
+  build.run_tasks({ { "make", target.name, "-j", tostring(build.threads) } }, function(status)
     local filtered_messages = grep(build.message_view.messages, function(v) return type(v) == 'table' and v[1] == "error" end)
     if callback then callback(status == 0 and #filtered_messages or 1) end
   end)


### PR DESCRIPTION
Convert the build threads argument for the make backend to string to get the make backend working.

There may be a better way to do this that I am not aware of currently since I am not too familiar with the code yet.