### PR TITLE
Overlapping line visual bug fix

### DIFF
--- a/plugins/debugger/init.lua
+++ b/plugins/debugger/init.lua
@@ -274,7 +274,7 @@ function DocView:draw_line_gutter(vline, x, y, width)
   if model.state == "stopped" and debugger.instruction and debugger.instruction[1] == self.doc.abs_filename and idx == debugger.instruction[2] then
     renderer.draw_rect(x, y+1, self:get_gutter_width(), self:get_line_height()-2, style.debugger.instruction)
   end
-  draw_line_gutter(self, vline, x, y, width)
+  return draw_line_gutter(self, vline, x, y, width)
 end
 
 function DocView:update()


### PR DESCRIPTION
Fixed a visual bug where due to improper function returning causes improper line padding when used with Linewrapping plugin.

### Following is the picture of the result of said bug:
<img width="473" height="964" alt="liteide-visualbug" src="https://github.com/user-attachments/assets/4acd89ef-5d71-4bda-8ad1-3e5bf5bb6975" />
