### PR TITLE
Update CMake clean, rework Shell backend and fix target ui item string on default target

### DIFF
--- a/plugins/build/backends/cmake.lua
+++ b/plugins/build/backends/cmake.lua
@@ -14,7 +14,7 @@ end
 
 function cmake.infer()
   return system.get_file_info(core.root_project().path .. PATHSEP .. "CMakeLists.txt") and {
-    { name = "debug" },
+    { name = "debug", buildtype = "debug" },
     { name = "release", buildtype = "release" }
   }
 end
@@ -74,8 +74,17 @@ end
 
 
 function cmake.clean(target, callback)
-  if system.get_file_info(get_build_directory(target)) then common.rm(get_build_directory(target), true) end
-  callback(0)
+  local bd = get_build_directory(target)
+
+  local cmd = { "cmake", "--build", bd, "--target", "clean" }
+ 
+  build.run_tasks({ cmd }, function(status)
+    if callback then 
+      callback(status) 
+    end
+  end, function(line)
+    build.message_view:add_message(build.parse_compile_line(line))
+  end)
 end
 
 

--- a/plugins/build/backends/shell.lua
+++ b/plugins/build/backends/shell.lua
@@ -24,7 +24,7 @@ local function get_args_build(target)
 end
 
 function shell.infer()
-  return nil and {
+  return system.get_file_info(core.root.project().path .. PATHSEP .. "build.sh") and {
     { name = "debug", arguments = { "-g" } },
     { name = "release" }
   }

--- a/plugins/build/backends/shell.lua
+++ b/plugins/build/backends/shell.lua
@@ -3,24 +3,44 @@ local build = require "plugins.build"
 
 local shell = { }
 
+--[[
+target.runner_name = name of runner     (default = sh)
+target.script_name = path to script     (default = build.sh)
+target.args_build  = list of build args (default = )
+target.args_clean  = list of clean args (default = clean)
+]]
+
+local function get_script_name(target)
+    return target.script_name or "build.sh"
+end
+local function get_runner_name(target)
+    return target.runner_name or "sh"
+end
+local function get_args_clean(target)
+    return table.unpack(target.args_clean or {"clean"})
+end
+local function get_args_build(target)
+    return table.unpack(target.args_build or {})
+end
+
 function shell.infer()
-  return system.get_file_info(core.root_project().path .. PATHSEP .. "build.sh") and {
+  return nil and {
     { name = "debug", arguments = { "-g" } },
     { name = "release" }
   }
 end
 
-local function grep(t, cond) local nt = {} for i,v in ipairs(t) do if cond(v, i) then table.insert(nt, v) end end return nt end
 function shell.build(target, callback)
-  build.run_tasks({ { target.command or "./build.sh", table.unpack(target.arguments or {}) } }, function(status)
-    local filtered_messages = grep(build.message_view.messages, function(v) return type(v) == 'table' and v[1] == "error" end)
-    if callback then callback(status == 0 and #filtered_messages or 1) end
+  build.run_tasks({ { get_runner_name(target), get_script_name(target), get_args_build(target) } }, function(status)
+    if callback then callback(status) end
+  end, function(line)
+    build.message_view:add_message(build.parse_compile_line(line))
   end)
 end
 
 
 function shell.clean(target, callback)
-  build.run_tasks({ { target.command or "./build.sh", "clean" } }, callback)
+  build.run_tasks({ { get_runner_name(target), get_script_name(target), get_args_clean(target) } }, callback)
 end
 
 

--- a/plugins/build/backends/shell.lua
+++ b/plugins/build/backends/shell.lua
@@ -24,7 +24,7 @@ local function get_args_build(target)
 end
 
 function shell.infer()
-  return system.get_file_info(core.root.project().path .. PATHSEP .. "build.sh") and {
+  return system.get_file_info(core.root_project().path .. PATHSEP .. "build.sh") and {
     { name = "debug", arguments = { "-g" } },
     { name = "release" }
   }

--- a/plugins/build/backends/shell.lua
+++ b/plugins/build/backends/shell.lua
@@ -11,16 +11,16 @@ target.args_clean  = list of clean args (default = clean)
 ]]
 
 local function get_script_name(target)
-    return target.script_name or "build.sh"
+    return target.command or "build.sh"
 end
 local function get_runner_name(target)
-    return target.runner_name or "sh"
+    return target.runner or "sh"
 end
 local function get_args_clean(target)
     return table.unpack(target.args_clean or {"clean"})
 end
 local function get_args_build(target)
-    return table.unpack(target.args_build or {})
+    return table.unpack(target.arguments or target.args_build or {})
 end
 
 function shell.infer()

--- a/plugins/build/init.lua
+++ b/plugins/build/init.lua
@@ -890,7 +890,7 @@ core.add_thread(function()
     if #targets == 0 then
       local internal = build.get_backends("internal")
       for _, target in ipairs(internal.infer() or {}) do
-        target.backend = internl
+        target.backend = internal
         table.insert(targets, target)
       end
     end

--- a/plugins/build/init.lua
+++ b/plugins/build/init.lua
@@ -278,6 +278,15 @@ function build.is_running() return build.thread ~= nil end
 function build.output(line) core.log_quiet(line) end
 
 function build.set_target(target)
+  if not build.targets or #build.targets == 0 then
+    core.log_quiet("No build targets available")
+    return
+  end
+  if not target then
+    core.log_quiet("No target given")
+    return
+  end
+
   target = common.clamp(target, 1, #build.targets)
   config.target_binary = build.targets and build.targets[target] and build.targets[target].binary
   local arguments = ""
@@ -435,7 +444,7 @@ core.status_view:add_item({
   get_item = function()
     local dv = core.active_view
     return {
-      style.text, string.format("target: %s (%s)", build.targets[build.state.target].name, build.targets[build.state.target].backend.id)
+      style.text, string.format("target: %s (%s)", build.targets[build.state.target].name or "default", build.targets[build.state.target].backend.id)
     }
   end,
   command = function()
@@ -796,6 +805,10 @@ local function select_target_commandview(submit, target, condition)
   if target then submit(target) end
   local target_names = {}
   for i,v in ipairs(build.targets) do if (not condition or condition(v)) then table.insert(target_names, v.name) end end
+  if #target_names == 0 then
+    core.log("No targets found")
+    return
+  end
   core.command_view:enter("Select Target", {
     submit = function(text)
       for i,v in ipairs(build.targets) do if v.name == text then submit(v, i) end end
@@ -877,7 +890,7 @@ core.add_thread(function()
     if #targets == 0 then
       local internal = build.get_backends("internal")
       for _, target in ipairs(internal.infer() or {}) do
-        target.backend = internal
+        target.backend = internl
         table.insert(targets, target)
       end
     end


### PR DESCRIPTION
Just that the title says. I removed the rmtree command in cmake to use its internal clean command, incase someone has "." as the build directory. furthermore, i kinda of upgraded the Shell backend to support more than shell, for example, calling a py build script, and custom arguments for both build and clean.

and the ui string for target on default.

I also removed that hardcoded grepping for an error string, which would not work in cases like different languages.